### PR TITLE
Added missing ENUM, and packet source IP identification

### DIFF
--- a/src/pcars/enums.py
+++ b/src/pcars/enums.py
@@ -18,6 +18,7 @@ class GameState(Enum):
     INGAME_PAUSED = 3
     INGAME_RESTARTING = 4
     INGAME_REPLAYING = 5
+    REPLAY_WATCHING = 6
 
 
 class RaceState(Enum):

--- a/src/pcars/stream.py
+++ b/src/pcars/stream.py
@@ -29,7 +29,7 @@ class PCarsStreamReceiver(Thread):
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
 
         while True:
-            data = sock.recv(1400)
+            data, address = sock.recvfrom(1400)
             packet = Packet.readFrom(BytesIO(data))
             for listener in self.listeners:
-                listener.handlePacket(packet)
+                listener.handlePacket(packet, address)


### PR DESCRIPTION
enum.py - Added the missing "REPLAY_WATCHING" item from GameState

stream.py - Changed the socket receive function to allow the identification of the IP sending the multicast packets - useful for LAN party. There's probably a better way to handle this so others wouldn't need to necessarily change their handlePacket methods..?